### PR TITLE
Match defaults to files from installation

### DIFF
--- a/json/default.json
+++ b/json/default.json
@@ -1,6 +1,6 @@
 {
 "spectra file": "spectra/spectra.mgf",
-"kernel file": "kernels/crap.KR.kernel,kernels/Saccharomyces_cerevisiae.R64-1-1.KR.kernel", 
+"kernel file": "kernels/crap.KR.kernel.gz,kernels/Saccharomyces_cerevisiae.R64-1-1.KR.kernel.gz", 
 "output file": "results/spectra.tsv",
 "fragment mass tolerance": 20,
 "parent mass tolerance": 10,


### PR DESCRIPTION
Hey there,

The kernel files in the installation are compressed, but the defaults have the uncompressed filenames, causing the program to crash in the tutorial. Here's the small fix to make that work out of the box.

Cheers,

AC